### PR TITLE
bug fixed

### DIFF
--- a/js/model.js
+++ b/js/model.js
@@ -10,7 +10,6 @@ var Model = Model || {};
         var output = [];
         
         recursive(nodes, output);
-        
         return output;
     }
 
@@ -66,7 +65,7 @@ var Model = Model || {};
             editor.focus();
         }
         
-        parser();
+        cbWrite();
     }
     
     model_.init = function(param) {


### PR DESCRIPTION
색깔 변할 때  parser 함수만 불렀던 것이 버그.

colorT 함수도 같이 불러줘야했음.

colorT를 main에 빼둔 것은 바꾼 태그를 그리고, 렌더링하는 일이기 때문에 Model에서 빼뒀다.

하지만 makeColor 같은 경우 텍스트의 색깔을 변경하는 것이기 때문에 Model에서 하는 일이라고 생각했고, 변경한 것을 다시 preview canvas에서 보여주려면 cbWrite() 함수를 콜해야했다.

어떤게 좋은 설계인지 다시 고민해보자...